### PR TITLE
Refactor user status to use string values

### DIFF
--- a/src/app/components/user/user-form/user-form.component.html
+++ b/src/app/components/user/user-form/user-form.component.html
@@ -110,11 +110,14 @@
         <option value="">
           Seleccione un estatus
         </option>
-        <option value="true">
+        <option value="active">
           Activo
         </option>
-        <option value="false">
+        <option value="blocked">
           Bloqueado
+        </option>
+        <option value="disabled">
+          Desactivado
         </option>
       </select>
 

--- a/src/app/components/user/user-list/user-list.component.html
+++ b/src/app/components/user/user-list/user-list.component.html
@@ -23,7 +23,7 @@
         <td class="p-3" scope="row">{{item.lastname2}}</td>
         <td class="p-3" scope="row">{{item.birthDate | date: 'dd/MM/yyyy'}}</td>
         <td class="p-3" scope="row">{{item.email}}</td>
-        <th class="p-3" scope="col">{{(item.status ? "Activo" : "Bloqueado")}}</th>
+        <th class="p-3" scope="col">{{statusText(item.status)}}</th>
         <td class="p-3 space-x-1">
           <button (click)="callModalAction.emit(item);" class="bg-flamenco px-2 p-0.5 rounded-md" type="button">
             <span class="material-symbols-rounded text-lg text-bisque">

--- a/src/app/components/user/user-list/user-list.component.ts
+++ b/src/app/components/user/user-list/user-list.component.ts
@@ -42,4 +42,17 @@ export class UserListComponent {
     }
     this.selectedUser = null;
   }
+
+  statusText(status: IUser["status"]): string {
+    switch (status) {
+      case 'active':
+        return 'Activo';
+      case 'blocked':
+        return 'Bloqueado';
+      case 'disabled':
+        return 'Desactivado';
+      default:
+        return 'Desconocido';
+    }
+  }
 }

--- a/src/app/interfaces/index.ts
+++ b/src/app/interfaces/index.ts
@@ -18,7 +18,7 @@ export interface IUser {
   birthDate?: string;
   email?: string;
   password?: string;
-  status?: boolean;
+  status?: string;
   createdAt?: string;
   updatedAt?: string;
   authorities?: IAuthority[];
@@ -76,7 +76,7 @@ export interface IDetailInvoice {
   category?: string;
   total?: number;
   description?: string;
-  
+
 }
 
 export interface IInvoiceUser {

--- a/src/app/pages/auth/login/login.component.html
+++ b/src/app/pages/auth/login/login.component.html
@@ -92,3 +92,13 @@
     </p>
   </app-modal>
 </ng-template>
+
+<ng-template #disabledUserModal>
+  <app-modal (callConfirmationMethod)="hideModal()" [confirmAction]="'Cerrar'" [title]="'Cuenta desactivada.'"
+    [textCenter]="true" [icon]="'block'">
+    <p class="text-bisque text-base max-w-lg">
+      Tu cuenta ha sido desactivada. Si crees que se trata de un error, por favor comunícate con el administrador del
+      sistema.
+    </p>
+  </app-modal>
+</ng-template>

--- a/src/app/pages/auth/login/login.component.ts
+++ b/src/app/pages/auth/login/login.component.ts
@@ -19,6 +19,7 @@ export class LoginComponent {
   @ViewChild('password') passwordModel!: NgModel;
   @ViewChild('expiredTokenModal') public expiredTokenModal: any;
   @ViewChild('blockedUserModal') public blockedUserModal: any;
+  @ViewChild('disabledUserModal') public disabledUserModal: any;
   public modalService: ModalService = inject(ModalService);
   private previousEmail: string = '';
   private actualEmail: string = '';
@@ -68,10 +69,13 @@ export class LoginComponent {
 
       this.authService.login(this.loginForm).subscribe({
         next: () => {
-          if (this.authService.userStatus) {
+          if (this.authService.userStatus === 'active') {
             this.router.navigateByUrl('/app/home');
-          } else {
+          } else if (this.authService.userStatus === 'blocked') {
             this.modalService.displayModal(this.blockedUserModal);
+            this.authService.logout();
+          } else if (this.authService.userStatus === 'disabled') {
+            this.modalService.displayModal(this.disabledUserModal);
             this.authService.logout();
           }
         },

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -1,7 +1,7 @@
 import { inject, Injectable } from '@angular/core';
 import { IAuthority, ILoginResponse, IResponse, IRoleType, IUser } from '../interfaces';
 import { Observable, tap } from 'rxjs';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpResponse } from '@angular/common/http';
 
 @Injectable({
   providedIn: 'root',
@@ -12,7 +12,7 @@ export class AuthService {
   private user: IUser = { email: '', authorities: [] };
   private http: HttpClient = inject(HttpClient);
   public tokenIsExpired: boolean = false;
-  public userStatus: boolean = true;
+  public userStatus: string = 'active';
 
   constructor() {
     this.load();
@@ -92,11 +92,12 @@ export class AuthService {
         this.user.email = credentials.email;
         this.expiresIn = response.expiresIn;
         this.user = response.authUser;
-        this.userStatus = this.user.status ? this.user.status : false;
+        this.userStatus = this.user.status ?? 'active';
         this.save();
       })
     );
   }
+
 
   changePassword(userId: number, password: { currentPassword: string; newPassword: string }) {
     return this.http.patch(`users/change-password/${userId}`, password);

--- a/src/app/services/invoice.service.ts
+++ b/src/app/services/invoice.service.ts
@@ -10,7 +10,7 @@ import { tap, catchError } from "rxjs/operators";
 })
 
 export class InvoiceService extends BaseService<IManualInvoice> {
-  protected override source: string = 'invoice';
+  protected override source: string = 'invoices';
   private invoicesList = signal<IManualInvoice[]>([]);
   private invoicesByUserIdList = signal<IManualInvoice[]>([]);
   get invoices$() {


### PR DESCRIPTION
This pull request introduces changes to improve user status handling across the application, including updates to interfaces, components, and services. The changes replace the previous boolean-based user status with a string-based approach to support multiple states (`active`, `blocked`, `disabled`). Additionally, a new modal is introduced for disabled user accounts, and minor adjustments are made to other parts of the codebase.

### User Status Handling Updates:
* [`src/app/interfaces/index.ts`](diffhunk://#diff-3ce6764de3f22a296c15f63f6cb08a9ca29f12934e8d2f613f2cab2dad405497L21-R21): Updated the `IUser` interface to use a `string` type for the `status` property instead of `boolean`.
* [`src/app/components/user/user-form/user-form.component.html`](diffhunk://#diff-6b2ee82213150f464b9a6790600b4f8371ee64234086938c399e3fe139401d45L113-R121): Modified the user status dropdown to include `active`, `blocked`, and `disabled` options.
* [`src/app/components/user/user-list/user-list.component.html`](diffhunk://#diff-b60846941575d2744ef38a307f0af3f9c8749840e54e789d6d66817165af43b6L26-R26): Replaced inline status logic with a call to the new `statusText` method.
* [`src/app/components/user/user-list/user-list.component.ts`](diffhunk://#diff-2966c73af1290418277a7818c0588334ff3d2999a24ace92ccf332350da719f1R45-R57): Added the `statusText` method to map status values (`active`, `blocked`, `disabled`) to their corresponding text labels.
* [`src/app/services/auth.service.ts`](diffhunk://#diff-1021f37d3b565f3a27ad943ee912af8176aad8792ac1b32c29689144a498e1caL15-R15): Updated `userStatus` to use a default value of `active` and adjusted logic to handle the new string-based statuses. [[1]](diffhunk://#diff-1021f37d3b565f3a27ad943ee912af8176aad8792ac1b32c29689144a498e1caL15-R15) [[2]](diffhunk://#diff-1021f37d3b565f3a27ad943ee912af8176aad8792ac1b32c29689144a498e1caL95-R101)

### Disabled User Modal:
* [`src/app/pages/auth/login/login.component.html`](diffhunk://#diff-656c042f346a2558c7552193361de3aac9ab601f725a2ecbf7bbd99627e52f0fR95-R104): Added a new modal template to notify users when their account is disabled.
* [`src/app/pages/auth/login/login.component.ts`](diffhunk://#diff-355123b3d80858b2ed15a0b3068b01fd04cbf88bceae1c2a82f663f88ea271b3R22): Integrated the new modal into the login flow and added a check for the `disabled` status during login. [[1]](diffhunk://#diff-355123b3d80858b2ed15a0b3068b01fd04cbf88bceae1c2a82f663f88ea271b3R22) [[2]](diffhunk://#diff-355123b3d80858b2ed15a0b3068b01fd04cbf88bceae1c2a82f663f88ea271b3L71-R79)

### Miscellaneous Adjustments:
* [`src/app/services/auth.service.ts`](diffhunk://#diff-1021f37d3b565f3a27ad943ee912af8176aad8792ac1b32c29689144a498e1caL4-R4): Added `HttpResponse` import for potential future enhancements.
* [`src/app/services/invoice.service.ts`](diffhunk://#diff-8e2f7b5b33662bde9e019447cc1d2baca33335764877ae3d1ae38c9959bd523dL13-R13): Corrected the `source` property from `invoice` to `invoices`.Changed user status from boolean to string ('active', 'blocked', 'disabled') across interfaces, components, and services. Updated UI to display appropriate status text and added handling for disabled accounts in the login flow. Also fixed invoice service endpoint to use plural form.