### PR TITLE
Fix person field mapping in invoice forms

### DIFF
--- a/src/app/components/manual-invoices/manual-invoices-form/manual-invoices-form.component.ts
+++ b/src/app/components/manual-invoices/manual-invoices-form/manual-invoices-form.component.ts
@@ -151,14 +151,7 @@ export class ManualInvoicesFormComponent implements OnInit {
   }
 
   updateFormForType(data: any) {
-    const person = data.receiver || data.issuer || {};
-    let firstName = '', lastName = '';
-
-    if (person.name) {
-      const fullName = person.name.trim().split(/\s+/);
-      firstName = fullName[0];
-      lastName = fullName.slice(1).join(' ');
-    }
+    const person = data.type === 'ingreso' ? data.receiver || {} : data.type === 'gasto' ? data.issuer || {} : {};
 
     this.invoiceForm.patchValue({
       type: data.type || '',
@@ -166,8 +159,8 @@ export class ManualInvoicesFormComponent implements OnInit {
       key: data.key || '',
       issueDate: data.issueDate || '',
       identification: person.identification || '',
-      name: firstName,
-      lastName: lastName,
+      name: person.name || '',
+      lastName: person.lastName || '',
       email: person.email || ''
     });
 

--- a/src/app/pages/create-simulation/create-simulation.component.ts
+++ b/src/app/pages/create-simulation/create-simulation.component.ts
@@ -160,15 +160,17 @@ export class CreateSimulationComponent {
     }
 
     const availableMonths = new Set<number>();
+
     invoices.forEach(invoice => {
       if (invoice.issueDate) {
-        const month = new Date(invoice.issueDate).getMonth() + 1;
-        availableMonths.add(month);
+        const [year, month, day] = invoice.issueDate.split('-').map(Number);
+        if (year && month && day) {
+          availableMonths.add(month);
+        }
       }
     });
 
     const filteredMonths = this.months.filter(month => availableMonths.has(month.value));
-
     return filteredMonths.length > 0 ? filteredMonths : this.months;
   }
 

--- a/src/app/pages/invoice/invoice.component.ts
+++ b/src/app/pages/invoice/invoice.component.ts
@@ -59,16 +59,18 @@ export class InvoiceComponent {
   });
 
   callEdition(invoice: IManualInvoice) {
+    const person = invoice.type === 'ingreso' ? invoice.receiver || {} : invoice.type === 'gasto' ? invoice.issuer || {} : {};
+
     this.invoiceForm.patchValue({
       id: JSON.stringify(invoice.id),
       type: invoice.type,
       consecutive: invoice.consecutive?.toString() || '',
       key: invoice.key,
       issueDate: invoice.issueDate,
-      identification: invoice.issuer?.identification,
-      name: invoice.issuer?.name,
-      lastName: invoice.issuer?.lastName,
-      email: invoice.issuer?.email
+      identification: person.identification || '',
+      name: person.name || '',
+      lastName: person.lastName || '',
+      email: person.email || ''
     });
 
     this.details = invoice.details ?? [];


### PR DESCRIPTION
This pull request refines how invoice-related forms handle and populate person data (such as name, last name, and identification) based on the invoice type. The changes ensure consistency in extracting person information for both "ingreso" and "gasto" invoices, and improve robustness when parsing invoice dates for filtering.

**Form and Data Handling Improvements:**

* Updated `updateFormForType` in `manual-invoices-form.component.ts` to consistently select the relevant person object (`receiver` for "ingreso", `issuer` for "gasto") and directly use `name` and `lastName` fields instead of splitting a full name string.
* Modified `callEdition` in `invoice.component.ts` to use the same logic for selecting person details based on invoice type, ensuring the form is populated with accurate data for both "ingreso" and "gasto" invoices.

**Date Parsing Robustness:**

* Improved the month extraction logic in `create-simulation.component.ts` by explicitly splitting and validating the `issueDate` string before adding the month to the filter set, making the code more robust against unexpected date formats.